### PR TITLE
libsks: fixes for  asymm_derivation

### DIFF
--- a/ta/secure_key_services/src/processing.c
+++ b/ta/secure_key_services/src/processing.c
@@ -287,9 +287,6 @@ static uint32_t generate_random_key_value(struct sks_attrs_head **head)
 	}
 	TEE_MemMove(&value_len, data, data_size);
 
-	if (get_type(*head) == SKS_CKK_GENERIC_SECRET)
-		value_len = (value_len + 7) / 8;
-
 	value = TEE_Malloc(value_len, TEE_USER_MEM_HINT_NO_FILL_ZERO);
 	if (!value)
 		return SKS_MEMORY;

--- a/ta/secure_key_services/src/processing_asymm.c
+++ b/ta/secure_key_services/src/processing_asymm.c
@@ -613,19 +613,13 @@ uint32_t do_asymm_derivation(struct pkcs11_session *session,
 	TEE_ObjectHandle out_handle = TEE_HANDLE_NULL;
 	void *a_ptr = NULL;
 	size_t a_size = 0;
-	uint32_t key_bit_size = 0;
 	uint32_t key_byte_size = 0;
 
 	TEE_MemFill(tee_attrs, 0, sizeof(tee_attrs));
 
-	rv = get_u32_attribute(*head, SKS_CKA_VALUE_LEN, &key_bit_size);
+	rv = get_u32_attribute(*head, SKS_CKA_VALUE_LEN, &key_byte_size);
 	if (rv)
 		return rv;
-
-	if (get_type(*head) != SKS_CKK_GENERIC_SECRET)
-		key_bit_size *= 8;
-
-	key_byte_size = (key_bit_size + 7) / 8;
 
 	res = TEE_AllocateTransientObject(TEE_TYPE_GENERIC_SECRET,
 					  key_byte_size * 8, &out_handle);
@@ -673,7 +667,7 @@ uint32_t do_asymm_derivation(struct pkcs11_session *session,
 	if (rv)
 		goto bail;
 
-	if (a_size * 8 < key_bit_size) {
+	if (a_size < key_byte_size) {
 		rv = SKS_CKR_KEY_SIZE_RANGE;
 	} else {
 		rv = add_attribute(head, SKS_CKA_VALUE, a_ptr, key_byte_size);

--- a/ta/secure_key_services/src/processing_ec.c
+++ b/ta/secure_key_services/src/processing_ec.c
@@ -1097,6 +1097,11 @@ uint32_t sks2tee_ecdh_param_pub(struct sks_attribute_head *proc_params,
 
 	*pub_size -= sizeof(uint8_t);
 
+	if (*pub_size >= 0x80) {
+		EMSG("DER long definitive form not yet supported");
+		return SKS_CKR_MECHANISM_INVALID;
+	}
+
 	return serialargs_get_ptr(&args, pub_data, *pub_size);
 }
 

--- a/ta/secure_key_services/src/processing_ec.c
+++ b/ta/secure_key_services/src/processing_ec.c
@@ -1083,7 +1083,21 @@ uint32_t sks2tee_ecdh_param_pub(struct sks_attribute_head *proc_params,
 
 	*pub_size = temp;
 
-	return serialargs_get_ptr(&args, pub_data, temp);
+	rv = serialargs_get(&args, &temp, sizeof(uint8_t));
+	if (rv)
+		return rv;
+
+	if (temp != 0x02 && temp != 0x03 && temp != 0x04)
+		return SKS_BAD_PARAM;
+
+	if (temp != 04) {
+		EMSG("DER compressed public key format not yet supported");
+		return SKS_CKR_MECHANISM_INVALID;
+	}
+
+	*pub_size -= sizeof(uint8_t);
+
+	return serialargs_get_ptr(&args, pub_data, *pub_size);
 }
 
 uint32_t sks2tee_algo_ecdsa(uint32_t *tee_id,


### PR DESCRIPTION
The public key passed to OP-TEE crypto was offset by one byte

Received:
I/TC: se050: ecc: : public x:
I/TC: se050: ecc: :     04.53.ec.ea.d3.f0.62.be 51.e6.2c.73.28.cd.20.8d
I/TC: se050: ecc: :     fc.e4.ba.e2.0f.27.51.74 c3.a0.50.e9.3d.63.47.f8
I/TC: se050: ecc: : public y:
I/TC: se050: ecc: :     84.ba.5d.07.1c.f2.fe.4e 12.66.cf.94.80.70.25.93
I/TC: se050: ecc: :     37.12.99.a4.e4.2c.c5.24 57.40.3e.9d.3e.13.24.9e

Should have been
I/TC: se050: ecc: : pair public x:
I/TC: se050: ecc: :     53.ec.ea.d3.f0.62.be.51 e6.2c.73.28.cd.20.8d.fc
I/TC: se050: ecc: :     e4.ba.e2.0f.27.51.74.c3 a0.50.e9.3d.63.47.f8.84
I/TC: se050: ecc: : pair public y:
I/TC: se050: ecc: :     ba.5d.07.1c.f2.fe.4e.12 66.cf.94.80.70.25.93.37
I/TC: se050: ecc: :     12.99.a4.e4.2c.c5.24.57 40.3e.9d.3e.13.24.9e.3a

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>